### PR TITLE
Fix nierozpoznawania bledu gracza w pierwszym ruchu

### DIFF
--- a/001-xoxoxo-obj/harness.py
+++ b/001-xoxoxo-obj/harness.py
@@ -22,13 +22,13 @@ class Harness():
 
       while True:
         move = self._inputs[player_id].get_move()
-        if move is None:
+        if move is False:
           self._output.show_move_error(player)
-          continue 
+          continue
 
         if self._game.make_move(move) is False:
           self._output.show_move_error(player)
-          continue
+          break
 
         break
 
@@ -49,7 +49,7 @@ def main():
   inputcon1 = InputCon()
   inputcon2 = InputCon()
   outputcon = OutputCon()
-      
+
   player_inputs = [ inputcon1, inputcon2 ]
   player_output = outputcon
 

--- a/001-xoxoxo-obj/harness.py
+++ b/001-xoxoxo-obj/harness.py
@@ -28,7 +28,7 @@ class Harness():
 
         if self._game.make_move(move) is False:
           self._output.show_move_error(player)
-          break
+          continue
 
         break
 


### PR DESCRIPTION
Przy pierwszym ruchu gracza i wysłaniu inputu spoza zakresu 0-8 powinien wyskoczyć błąd, a zamiast tego "x" zostaje postawiony w polu 0.
